### PR TITLE
Initial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# cfc_leftover_chips
-Prevents players from setting PP fallbacks on potentially harmful entities (E2, Starfall, etc.)
+# cfc_leftovers
+Prevents players from persisting potentially harmful or annoying entities (E2, Starfall, etc.)

--- a/moon/autorun/server/cfc_leftover_chips.moon
+++ b/moon/autorun/server/cfc_leftover_chips.moon
@@ -21,19 +21,20 @@ checkProperty = {
 leftovers = {}
 
 onCreate = (ent) ->
-    return unless IsValid ent
-    return unless watchedEntities[ent\GetClass!]
+    timer.Simple 0, ->
+        return unless IsValid ent
+        return unless rawget watchedEntities, ent\GetClass!
 
-    rawset leftovers, ent, true
+        rawset leftovers, ent, true
 
-    ent\CallOnRemove "CFC_Leftovers_Untrack", ->
-        rawset leftovers, ent, nil
+        ent\CallOnRemove "CFC_Leftovers_Untrack", ->
+            rawset leftovers, ent, nil
 hook.Create "OnEntityCreated", "CFC_Leftovers_Track", onCreate
 
 cleanup = ->
     for leftover in pairs leftovers
         if IsValid leftover
-            property = checkProperty[leftover\GetClass!]
+            property = rawget checkProperty, leftover\GetClass!
             continue if IsValid leftover[property]
 
         SafeRemoveEntityDelayed leftover, 0

--- a/moon/autorun/server/cfc_leftover_chips.moon
+++ b/moon/autorun/server/cfc_leftover_chips.moon
@@ -22,12 +22,13 @@ leftovers = {}
 
 onCreate = (ent) ->
     return unless IsValid ent
-    return unless leftovers[ent\GetClass!]
+    return unless watchedEntities[ent\GetClass!]
 
-    rawset watchedEntities, ent, true
+    rawset leftovers, ent, true
 
-    ent\CallOnRemove "CFC_LeftoverChips_Untrack", ->
-        rawset watchedEntities, ent, nil
+    ent\CallOnRemove "CFC_Leftovers_Untrack", ->
+        rawset leftovers, ent, nil
+hook.Create "OnEntityCreated", "CFC_Leftovers_Track"
 
 cleanup = ->
     for leftover in pairs leftovers
@@ -36,5 +37,4 @@ cleanup = ->
             continue if IsValid leftover[property]
 
         SafeRemoveEntityDelayed leftovers, 0
-
-hook.Add "PlayerDisconnected", "CFC_LeftoverChips_Cleanup", cleanup
+hook.Add "PlayerDisconnected", "CFC_Leftovers_Cleanup", cleanup

--- a/moon/autorun/server/cfc_leftover_chips.moon
+++ b/moon/autorun/server/cfc_leftover_chips.moon
@@ -1,0 +1,38 @@
+entsGetAll = ents.GetAll
+rawget = rawget
+rawset = rawset
+pairs = pairs
+IsValid = IsValid
+SafeRemoveEntityDelayed = SafeRemoveEntityDelayed
+
+leftovers = {
+    gmod_wire_expression_2: true
+    starfall_processor: true
+}
+
+-- Which property should be checked for validity to decide if this E2 has been abandoned
+checkProperty = {
+    gmod_wire_expression_2: "Founder"
+    starfall_processor: "owner"
+}
+
+watchedEntities = {}
+
+onCreate = (ent) ->
+    return unless IsValid ent
+    return unless leftovers[ent\GetClass!]
+
+    watchedEntities[ent] = true
+
+    ent\CallOnRemove "CFC_LeftoverChips_Untrack", ->
+        watchedEntities[ent] = nil
+
+cleanup = ->
+    for leftover in pairs leftovers
+        if IsValid leftover
+            property = checkProperty[leftover\GetClass!]
+            continue if IsValid leftover[property]
+
+        SafeRemoveEntityDelayed leftovers, 0
+
+hook.Add "PlayerDisconnected", "CFC_LeftoverChips_Cleanup", cleanup

--- a/moon/autorun/server/cfc_leftover_chips.moon
+++ b/moon/autorun/server/cfc_leftover_chips.moon
@@ -1,11 +1,11 @@
-entsGetAll = ents.GetAll
 rawget = rawget
 rawset = rawset
 pairs = pairs
 IsValid = IsValid
 SafeRemoveEntityDelayed = SafeRemoveEntityDelayed
 
-leftovers = {
+-- Which classes do we want to insist on destroying
+watchedEntities = {
     gmod_wire_expression_2: true
     starfall_processor: true
 }
@@ -16,16 +16,16 @@ checkProperty = {
     starfall_processor: "owner"
 }
 
-watchedEntities = {}
+leftovers = {}
 
 onCreate = (ent) ->
     return unless IsValid ent
     return unless leftovers[ent\GetClass!]
 
-    watchedEntities[ent] = true
+    rawset watchedEntities, ent, true
 
     ent\CallOnRemove "CFC_LeftoverChips_Untrack", ->
-        watchedEntities[ent] = nil
+        rawset watchedEntities, ent, nil
 
 cleanup = ->
     for leftover in pairs leftovers

--- a/moon/autorun/server/cfc_leftover_chips.moon
+++ b/moon/autorun/server/cfc_leftover_chips.moon
@@ -28,7 +28,7 @@ onCreate = (ent) ->
 
     ent\CallOnRemove "CFC_Leftovers_Untrack", ->
         rawset leftovers, ent, nil
-hook.Create "OnEntityCreated", "CFC_Leftovers_Track"
+hook.Create "OnEntityCreated", "CFC_Leftovers_Track", onCreate
 
 cleanup = ->
     for leftover in pairs leftovers
@@ -36,5 +36,5 @@ cleanup = ->
             property = checkProperty[leftover\GetClass!]
             continue if IsValid leftover[property]
 
-        SafeRemoveEntityDelayed leftovers, 0
+        SafeRemoveEntityDelayed leftover, 0
 hook.Add "PlayerDisconnected", "CFC_Leftovers_Cleanup", cleanup

--- a/moon/autorun/server/cfc_leftover_chips.moon
+++ b/moon/autorun/server/cfc_leftover_chips.moon
@@ -7,12 +7,14 @@ SafeRemoveEntityDelayed = SafeRemoveEntityDelayed
 -- Which classes do we want to insist on destroying
 watchedEntities = {
     gmod_wire_expression_2: true
+    gmod_wire_hologram: true
     starfall_processor: true
 }
 
 -- Which property should be checked for validity to decide if this E2 has been abandoned
 checkProperty = {
     gmod_wire_expression_2: "Founder"
+    gmod_wire_hologram: "Founder"
     starfall_processor: "owner"
 }
 


### PR DESCRIPTION
The goal is to make sure that malicious/annoying E2s, Starfalls, and other entities aren't persisted after a player disconnects. Whether by using PP fallbacks, regular deletion delays, or otherwise.